### PR TITLE
Update H2 Database to 2.0.206 to address CVE-2021-42392.

### DIFF
--- a/src/datalab/bksql/bksql-core/pom.xml
+++ b/src/datalab/bksql/bksql-core/pom.xml
@@ -59,7 +59,7 @@
         <httpclient.version>4.5.2</httpclient.version>
         <typesafe-config.version>1.2.1</typesafe-config.version>
         <jdbi3-core.version>3.2.1</jdbi3-core.version>
-        <h2database.version>1.4.197</h2database.version>
+        <h2database.version>2.0.206</h2database.version>
         <commons-compress.version>1.4.1</commons-compress.version>
         <snappy-java.version>1.1.4</snappy-java.version>
         <meta-client.version>4.0.0</meta-client.version>

--- a/src/datalab/bksql/bksql-metadata/pom.xml
+++ b/src/datalab/bksql/bksql-metadata/pom.xml
@@ -41,7 +41,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <bksql-core.version>4.0.0</bksql-core.version>
         <junit.version>4.12</junit.version>
-        <h2database.version>1.4.197</h2database.version>
+        <h2database.version>2.0.206</h2database.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     </properties>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42392